### PR TITLE
fix/ajouterTache-notEmpty: ajouterTache cannot be empty now

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,7 +3,7 @@ function gestionnaireDeTaches() {
     let tacheComplete = false;
 
     function ajouterTache(tache) {
-        if (tache != null) {
+        if (tache != null && tache != "") {
             taches.push(tache);
         }
     }


### PR DESCRIPTION
Ticket : [bug-002]
Description : Je souhaite que la fonction ajouterTache valide si la tâche est une chaîne vide
How to test : Check if ajouterTache can be use with empty string